### PR TITLE
Bugfix GetOrThrow. Return exception when NOT ok

### DIFF
--- a/Hya.Kadaster.Bag/Models/Result.cs
+++ b/Hya.Kadaster.Bag/Models/Result.cs
@@ -35,7 +35,7 @@ public class Result<T>
 
     public T GetOrThrow()
     {
-        if (_ok) throw _exception;
+        if (!_ok) throw _exception;
         return _value;
     }
 


### PR DESCRIPTION
Bugfix to be able to use GetOrThrow
Currently it throws an exception when the result is OK. This bugfix inverses the `if(_ok)` check to `if(!_ok)`.